### PR TITLE
Fix: Issue #16 (description: Restrict creating mines more than total cells) 

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
@@ -5,6 +5,7 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.update
 import com.arkivanov.minesweeper.game.GameSettings
 import com.arkivanov.minesweeper.settings.EditSettingsComponent.Model
+import kotlin.math.min
 
 internal class DefaultEditSettingsComponent(
     settings: GameSettings,
@@ -44,7 +45,7 @@ internal class DefaultEditSettingsComponent(
             GameSettings(
                 width = width,
                 height = height,
-                maxMines = maxMines,
+                maxMines = min(maxMines, width * height),
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
@@ -5,7 +5,6 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.update
 import com.arkivanov.minesweeper.game.GameSettings
 import com.arkivanov.minesweeper.settings.EditSettingsComponent.Model
-import kotlin.math.min
 
 internal class DefaultEditSettingsComponent(
     settings: GameSettings,
@@ -41,13 +40,11 @@ internal class DefaultEditSettingsComponent(
         val height = _model.value.height.toIntOrNull() ?: return
         val maxMines = _model.value.maxMines.toIntOrNull() ?: return
 
-        onConfirmed(
-            GameSettings(
-                width = width,
-                height = height,
-                maxMines = min(maxMines, width * height),
-            )
-        )
+        val finalWidth = width.coerceIn(2..100)
+        val finalHeight = height.coerceIn(2..50)
+        val finalMines = maxMines.coerceIn(1 until finalWidth * finalHeight - 1)
+
+        onConfirmed(GameSettings(width = finalWidth, height = finalHeight, maxMines = finalMines))
     }
 
     override fun onDismissRequested() {

--- a/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
@@ -6,10 +6,6 @@ import com.arkivanov.decompose.value.update
 import com.arkivanov.minesweeper.game.GameSettings
 import com.arkivanov.minesweeper.settings.EditSettingsComponent.Model
 
-private const val MIN_SIZE = 2
-private const val MAX_WIDTH = 100
-private const val MAX_HEIGHT = 50
-
 internal class DefaultEditSettingsComponent(
     settings: GameSettings,
     private val onConfirmed: (GameSettings) -> Unit,
@@ -44,9 +40,9 @@ internal class DefaultEditSettingsComponent(
         val height = _model.value.height.toIntOrNull() ?: return
         val maxMines = _model.value.maxMines.toIntOrNull() ?: return
 
-        val finalWidth = width.coerceIn(MIN_SIZE..MAX_WIDTH)
-        val finalHeight = height.coerceIn(MIN_SIZE..MAX_HEIGHT)
-        val finalMines = maxMines.coerceIn(1 until finalWidth * finalHeight - 1)
+        val finalWidth = width.coerceIn(2..100)
+        val finalHeight = height.coerceIn(2..50)
+        val finalMines = maxMines.coerceIn(1 until finalWidth * finalHeight)
 
         onConfirmed(GameSettings(width = finalWidth, height = finalHeight, maxMines = finalMines))
     }

--- a/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/arkivanov/minesweeper/settings/DefaultEditSettingsComponent.kt
@@ -6,6 +6,10 @@ import com.arkivanov.decompose.value.update
 import com.arkivanov.minesweeper.game.GameSettings
 import com.arkivanov.minesweeper.settings.EditSettingsComponent.Model
 
+private const val MIN_SIZE = 2
+private const val MAX_WIDTH = 100
+private const val MAX_HEIGHT = 50
+
 internal class DefaultEditSettingsComponent(
     settings: GameSettings,
     private val onConfirmed: (GameSettings) -> Unit,
@@ -40,8 +44,8 @@ internal class DefaultEditSettingsComponent(
         val height = _model.value.height.toIntOrNull() ?: return
         val maxMines = _model.value.maxMines.toIntOrNull() ?: return
 
-        val finalWidth = width.coerceIn(2..100)
-        val finalHeight = height.coerceIn(2..50)
+        val finalWidth = width.coerceIn(MIN_SIZE..MAX_WIDTH)
+        val finalHeight = height.coerceIn(MIN_SIZE..MAX_HEIGHT)
         val finalMines = maxMines.coerceIn(1 until finalWidth * finalHeight - 1)
 
         onConfirmed(GameSettings(width = finalWidth, height = finalHeight, maxMines = finalMines))


### PR DESCRIPTION
Solution of a problem raised at Issue https://github.com/arkivanov/Minesweeper/issues/16

Closes #16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Ensured the maximum number of mines in Minesweeper does not exceed the total number of cells.
	- Improved validation for width, height, and maximum mines to fall within specific ranges.
	- Introduced `coerceIn` to ensure proper range for width, height, and max mines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->